### PR TITLE
Fixed an issue where client daemons were not closed. Additional speed improvement!

### DIFF
--- a/dit_cli/client_daemons/js_daemon.js
+++ b/dit_cli/client_daemons/js_daemon.js
@@ -2,7 +2,7 @@ const net = require("net");
 const server = new net.Socket();
 const port = process.argv[2];
 server.connect(port, "127.0.0.1", () => {
-    server.write(JSON.stringify({ lang: "Javascript" }));
+    server.write(JSON.stringify({ type: "connect", lang: "Javascript" }));
 });
 
 server.on("data", (data) => {
@@ -10,9 +10,13 @@ server.on("data", (data) => {
     try {
         var script = require(data.toString());
         var result = script.run();
-        finalMessage = JSON.stringify({ crash: false, result: result.toString() });
+        finalMessage = JSON.stringify({
+            type: "job",
+            crash: false,
+            result: result.toString(),
+        });
     } catch (err) {
-        finalMessage = JSON.stringify({ crash: true, result: err.stack });
+        finalMessage = JSON.stringify({ type: "job", crash: true, result: err.stack });
     } finally {
         server.write(finalMessage);
     }

--- a/dit_cli/client_daemons/py_daemon.py
+++ b/dit_cli/client_daemons/py_daemon.py
@@ -2,15 +2,20 @@ import importlib.util
 import json
 import socket
 import sys
+import time
 import traceback
 
 
 def run_client():
     port = int(sys.argv[1])
-    with socket.create_connection(("127.0.0.1", port)) as server:
-        server.sendall(f'{{"lang": "Python"}}'.encode())
+    try:
+        server = socket.create_connection(("127.0.0.1", port))
+    except ConnectionRefusedError:
+        return
+    server.sendall(_encode({"type": "connect", "lang": "Python"}))
 
-        while True:
+    while True:
+        try:
             path = server.recv(1024).decode()
             if path:
                 try:
@@ -19,12 +24,22 @@ def run_client():
                     script = importlib.util.module_from_spec(spec)
                     spec.loader.exec_module(script)
                     result: str = script.run()
-                    job_mes = json.dumps({"crash": False, "result": str(result)})
+                    job_mes = {"type": "job", "crash": False, "result": str(result)}
                 except BaseException:
                     tb = traceback.format_exc()
-                    job_mes = json.dumps({"crash": True, "result": tb})
+                    job_mes = {"type": "job", "crash": True, "result": tb}
                 finally:
-                    server.sendall(job_mes.encode())
+                    server.sendall(_encode(job_mes))
+            else:
+                server.sendall(_encode({"type": "heart"}))
+            time.sleep(0.001)  # Prevent pinning the CPU
+        except BrokenPipeError:  # Server has closed
+            server.close()
+            break
+
+
+def _encode(message: dict):
+    return json.dumps(message).encode()
 
 
 run_client()


### PR DESCRIPTION
It turns out the Python client daemons were not closing, and were all left running. With ~30 clients all trying to receive messages, the CPU was pinned at 100, and made the performance tests I was doing much slower. I fixed the issue and cleaned up the client lifecycle in general, then reran the test. It now runs in 4.5 seconds! That's down from 25 seconds in the original #11 issue. This is the improvement I was really hoping for. Very happy about this!